### PR TITLE
replace azure-functions-worker with azure-function dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-azure-functions-worker==1.0.0b6
+azure-functions==1.0.0b5
 azure-storage-blob==2.0.1
 requests==2.22.0
 pytest==4.6.3


### PR DESCRIPTION
### What

Service currently broken due to module shifting to new package.

A used module does not exist in azure-functions-worker anymore; instead it exists in azure-functions

### How to review

Check azure function works locally, make sure you are pointing to development if you intend to run it.
