### PR TITLE
Postcode Builder -  timeout increase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+.DS_Store
+.gitignore.swp
+.idea/
+local.settings.json.dev.example
+local.settings.json.pre-prod.example
+
+
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/host.json
+++ b/host.json
@@ -4,5 +4,5 @@
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[1.*, 2.0.0)"
   },
-  "functionTimeout": "01:00:00"
+  "functionTimeout": "02:00:00"
 }


### PR DESCRIPTION
### What

Changed the timeout, as 1hr isn't long enough to complete the task. 

Options were 

1. Do a broader refactor and call a separate function with batches of (n) postcodes per batch. 
2. Extend the timeout beyond the theoretical maximum time required based on the current css postcode file. circa 1.8m postcodes process at an average rate of 1000 every 3 seconds = 90mins. Add some buffer time 2hrs on the timeout
3. set the timeout to -1 (infinite) future proof, but if a mistake is made in the code at a later date could lead to the function never stoping for some reason.

Went with 2 as no ticket for this and should keep it going for the foreseeable future.

### How to review
check the host.json file for the correct time value for function timeout against the azure docs

